### PR TITLE
Stats-9: Add player stats component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import {Players} from "./Components/Players/Players";
 const routes = {
     '/': () => <Home />,
     '/teams': () => <Teams />,
-    // '/players': () => <Players />,
+    '/players': () => <Players />,
   };
 
 const App = () => {

--- a/src/Components/NavBar/NavBar.js
+++ b/src/Components/NavBar/NavBar.js
@@ -11,7 +11,7 @@ const NavBar = () => {
       <div id={'links-div'}>
         <A className={'NavBarLink'} href={'/'}><button className='NavBarLinkButton'>Home</button></A>
         <A className={'NavBarLink'} href={'/teams'}><button className='NavBarLinkButton'>Teams</button></A>
-        {/*<A className={'NavBarLink'} href={'/players'}><button className='NavBarLinkButton'>Players</button></A>*/}
+        <A className={'NavBarLink'} href={'/players'}><button className='NavBarLinkButton'>Players</button></A>
       </div>
     </div>
   );

--- a/src/Components/Paginator/Paginator.js
+++ b/src/Components/Paginator/Paginator.js
@@ -4,10 +4,17 @@ import './Paginator.scss';
 const Paginator = (props) => {
   const [currentPageNumber, setCurrentPageNumber] = useState(1);
   const [maxPages, setMaxPages] = useState(1);
+  const [classname, setClassname] = useState('Paginator');
+
+  useEffect(() => {
+    if(props.className){
+      setClassname(props.className);
+    }
+  }, []);
 
   useEffect(() => {
     if(props.data){
-      setMaxPages(Math.ceil(props.data.length/props.dataPerPage))
+      setMaxPages(Math.ceil(props.data.length/props.dataPerPage));
     }
   }, [props.data]);
 
@@ -33,7 +40,7 @@ const Paginator = (props) => {
   }
 
   return (
-    <div className="Paginator">
+    <div className={classname}>
       <button onClick={handlePreviousClick}>Previous</button>
       <p>{currentPageNumber}</p>
       <button onClick={handleNextClick}>Next</button>

--- a/src/Components/Paginator/Paginator.js
+++ b/src/Components/Paginator/Paginator.js
@@ -11,6 +11,15 @@ const Paginator = (props) => {
     }
   }, [props.data]);
 
+  useEffect(() => {
+    if (props.data) {
+      let indexStart = props.dataPerPage * (currentPageNumber - 1);
+      let indexEnd = indexStart + props.dataPerPage;
+      let displayedData = props.data.slice(indexStart, indexEnd);
+      props.setDisplayedData(indexStart, indexEnd, displayedData);
+    }
+  }, [currentPageNumber]);
+
   function handlePreviousClick() {
     if(currentPageNumber > 1){
       setCurrentPageNumber(currentPageNumber - 1);

--- a/src/Components/Paginator/Paginator.js
+++ b/src/Components/Paginator/Paginator.js
@@ -1,0 +1,35 @@
+import React, {useState, useEffect} from 'react';
+import './Paginator.scss';
+
+const Paginator = (props) => {
+  const [currentPageNumber, setCurrentPageNumber] = useState(1);
+  const [maxPages, setMaxPages] = useState(1);
+
+  useEffect(() => {
+    if(props.data){
+      setMaxPages(Math.ceil(props.data.length/props.dataPerPage))
+    }
+  }, [props.data]);
+
+  function handlePreviousClick() {
+    if(currentPageNumber > 1){
+      setCurrentPageNumber(currentPageNumber - 1);
+    }
+  }
+
+  function handleNextClick() {
+    if(currentPageNumber < maxPages){
+      setCurrentPageNumber(currentPageNumber + 1);
+    }
+  }
+
+  return (
+    <div className="Paginator">
+      <button onClick={handlePreviousClick}>Previous</button>
+      <p>{currentPageNumber}</p>
+      <button onClick={handleNextClick}>Next</button>
+    </div>
+  );
+};
+
+export {Paginator};

--- a/src/Components/Paginator/Paginator.scss
+++ b/src/Components/Paginator/Paginator.scss
@@ -1,0 +1,3 @@
+.Paginator {
+  margin: 2em;
+}

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import './Players.scss';
 import {BASE_LOCAL_API, GOALIE, GOALIES, SKATERS} from "../../Extras/Constants";
+import {Paginator} from "../Paginator/Paginator";
 
 const Players = () => {
   const [allPlayers, setAllPlayers] = useState(null);
@@ -99,13 +100,16 @@ const Players = () => {
 
   return (
     <div className="Players">
-      <div>
+      <div id={'Players-type-dropdown-div'}>
         <select name="player-type" id="player-type-dropdown" onChange={handlePlayerFilterChange}>
           <option value={SKATERS}>Skaters</option>
           <option value={GOALIES}>Goalies</option>
         </select>
       </div>
       {getPlayerTable()}
+      <div id={'Players-pagination'}>
+        <Paginator data={filteredPlayers} dataPerPage={20} />
+      </div>
     </div>
   );
 };

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -1,10 +1,77 @@
 import React, {useState, useEffect} from 'react';
 import './Players.scss';
+import {BASE_LOCAL_API} from "../../Extras/Constants";
 
 const Players = () => {
+  const [allPlayers, setAllPlayers] = useState(null);
+  useEffect( () => {
+    fetch(BASE_LOCAL_API + '/players')
+      .then(results => results.json())
+      .then(res => {
+        setAllPlayers(res);
+      });
+  }, []);
+
+  function getPlayerTable(){
+    if(allPlayers === null){
+      return <p>Loading...</p>
+    } else {
+      return <div id={'PlayerStatsTable-div'}>
+        <table id={'PlayerStatsTable'}>
+          <tr>
+            <th>Player Name</th>
+            <th>Position</th>
+            <th>Games Played</th>
+            <th>Goals</th>
+            <th>Assists</th>
+            <th>Points</th>
+            <th>+/-</th>
+            <th>Shots</th>
+            <th>Shot %</th>
+            <th>Shifts</th>
+            <th>TOI/G</th>
+            <th>Blocked Shots</th>
+            <th>Hits</th>
+            <th>PIM</th>
+            <th>SHG</th>
+            <th>SHP</th>
+            <th>SHTOI</th>
+            <th>PPG</th>
+            <th>PPP</th>
+            <th>PPTOI</th>
+          </tr>
+          {allPlayers.map(player => {
+            return <tr>
+              <td>{player.player.fullName}</td>
+              <td>{player.position.abbreviation}</td>
+              <td>{player.stats.games}</td>
+              <td>{player.stats.goals}</td>
+              <td>{player.stats.assists}</td>
+              <td>{player.stats.points}</td>
+              <td>{player.stats.plusMinus}</td>
+              <td>{player.stats.shots}</td>
+              <td>{player.stats.shotPct}%</td>
+              <td>{player.stats.shifts}</td>
+              <td>{player.stats.timeOnIcePerGame}</td>
+              <td>{player.stats.blocked}</td>
+              <td>{player.stats.hits}</td>
+              <td>{player.stats.pim}</td>
+              <td>{player.stats.shortHandedGoals}</td>
+              <td>{player.stats.shortHandedPoints}</td>
+              <td>{player.stats.shortHandedTimeOnIcePerGame}</td>
+              <td>{player.stats.powerPlayGoals}</td>
+              <td>{player.stats.powerPlayPoints}</td>
+              <td>{player.stats.powerPlayTimeOnIcePerGame}</td>
+            </tr>
+          })}
+        </table>
+      </div>
+    }
+  }
+
   return (
     <div className="Players">
-      <h1>Players Screen here</h1>
+      {getPlayerTable()}
     </div>
   );
 };

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -21,14 +21,6 @@ const Players = () => {
     filterPlayers();
   }, [allPlayers, filter]);
 
-  // useEffect( () => {
-  //   debugger;
-  //   let players = filteredPlayers;
-  //   if (filteredPlayers){
-  //     setDisplayedPlayers(filteredPlayers.slice(playerIndexStart, playerIndexStart + 20));
-  //   }
-  // }, [filteredPlayers]);
-
   function filterPlayers() {
     if (allPlayers) {
       if (filter === SKATERS) {

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -7,6 +7,7 @@ const Players = () => {
   const [allPlayers, setAllPlayers] = useState(null);
   const [filteredPlayers, setFilteredPlayers] = useState(null);
   const [displayedPlayers, setDisplayedPlayers] = useState(null);
+  const [playerIndexStart, setPlayerIndexStart] = useState(0);
   const [filter, setFilter] = useState(SKATERS);
   useEffect( () => {
     fetch(BASE_LOCAL_API + '/players')
@@ -20,21 +21,32 @@ const Players = () => {
     filterPlayers();
   }, [allPlayers, filter]);
 
+  // useEffect( () => {
+  //   debugger;
+  //   let players = filteredPlayers;
+  //   if (filteredPlayers){
+  //     setDisplayedPlayers(filteredPlayers.slice(playerIndexStart, playerIndexStart + 20));
+  //   }
+  // }, [filteredPlayers]);
+
   function filterPlayers() {
     if (allPlayers) {
       if (filter === SKATERS) {
-        setFilteredPlayers(allPlayers.filter(player => {
+        let filtered = allPlayers.filter(player => {
           return player.position.code.toLowerCase() !== GOALIE;
-        }));
+        });
+        setFilteredPlayers(filtered);
+        setDisplayedPlayers(filtered.slice(0, 20));
       } else {
-        setFilteredPlayers(allPlayers.filter(player => {
+        let filtered = allPlayers.filter(player => {
           return player.position.code.toLowerCase() === GOALIE;
-        }))
+        });
+        setFilteredPlayers(filtered);
+        setDisplayedPlayers(filtered.slice(0, 20));
       }
     }
   }
 
-  const [playerIndexStart, setPlayerIndexStart] = useState(0);
   function setDisplayedData(indexStart, indexEnd, players){
     setPlayerIndexStart(indexStart);
     setDisplayedPlayers(players);

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -6,6 +6,7 @@ import {Paginator} from "../Paginator/Paginator";
 const Players = () => {
   const [allPlayers, setAllPlayers] = useState(null);
   const [filteredPlayers, setFilteredPlayers] = useState(null);
+  const [displayedPlayers, setDisplayedPlayers] = useState(null);
   const [filter, setFilter] = useState(SKATERS);
   useEffect( () => {
     fetch(BASE_LOCAL_API + '/players')
@@ -33,8 +34,14 @@ const Players = () => {
     }
   }
 
+  const [playerIndexStart, setPlayerIndexStart] = useState(0);
+  function setDisplayedData(indexStart, indexEnd, players){
+    setPlayerIndexStart(indexStart);
+    setDisplayedPlayers(players);
+  }
+
   function getPlayerTable(){
-    if(filteredPlayers === null){
+    if(displayedPlayers === null){
       return <p>Loading...</p>
     } else {
       return <div id={'PlayerStatsTable-div'}>
@@ -63,9 +70,9 @@ const Players = () => {
             <th>PPTOI</th>
             <th>GWG</th>
           </tr>
-          {filteredPlayers.map((player, index) => {
+          {displayedPlayers.map((player, index) => {
             return <tr>
-              <td>{index + 1}</td>
+              <td>{playerIndexStart + index + 1}</td>
               <td>{player.player.fullName}</td>
               <td>{player.position.abbreviation}</td>
               <td>{player.stats.games}</td>
@@ -108,7 +115,7 @@ const Players = () => {
       </div>
       {getPlayerTable()}
       <div id={'Players-pagination'}>
-        <Paginator data={filteredPlayers} dataPerPage={20} />
+        <Paginator data={filteredPlayers} setDisplayedData={setDisplayedData} dataPerPage={20} />
       </div>
     </div>
   );

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -119,7 +119,7 @@ const Players = () => {
       </div>
       {getPlayerTable()}
       <div id={'Players-pagination'}>
-        <Paginator data={filteredPlayers} setDisplayedData={setDisplayedData} dataPerPage={20} />
+        <Paginator className={'Player-Paginator'} data={filteredPlayers} setDisplayedData={setDisplayedData} dataPerPage={20} />
       </div>
     </div>
   );

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -1,9 +1,11 @@
 import React, {useState, useEffect} from 'react';
 import './Players.scss';
-import {BASE_LOCAL_API} from "../../Extras/Constants";
+import {BASE_LOCAL_API, GOALIE, GOALIES, SKATERS} from "../../Extras/Constants";
 
 const Players = () => {
   const [allPlayers, setAllPlayers] = useState(null);
+  const [filteredPlayers, setFilteredPlayers] = useState(null);
+  const [filter, setFilter] = useState(SKATERS);
   useEffect( () => {
     fetch(BASE_LOCAL_API + '/players')
       .then(results => results.json())
@@ -12,8 +14,26 @@ const Players = () => {
       });
   }, []);
 
+  useEffect( () => {
+    filterPlayers();
+  }, [allPlayers, filter]);
+
+  function filterPlayers() {
+    if (allPlayers) {
+      if (filter === SKATERS) {
+        setFilteredPlayers(allPlayers.filter(player => {
+          return player.position.code.toLowerCase() !== GOALIE;
+        }));
+      } else {
+        setFilteredPlayers(allPlayers.filter(player => {
+          return player.position.code.toLowerCase() === GOALIE;
+        }))
+      }
+    }
+  }
+
   function getPlayerTable(){
-    if(allPlayers === null){
+    if(filteredPlayers === null){
       return <p>Loading...</p>
     } else {
       return <div id={'PlayerStatsTable-div'}>
@@ -42,7 +62,7 @@ const Players = () => {
             <th>PPTOI</th>
             <th>GWG</th>
           </tr>
-          {allPlayers.map((player, index) => {
+          {filteredPlayers.map((player, index) => {
             return <tr>
               <td>{index + 1}</td>
               <td>{player.player.fullName}</td>
@@ -73,8 +93,18 @@ const Players = () => {
     }
   }
 
+  function handlePlayerFilterChange(e){
+    setFilter(e.target.value);
+  }
+
   return (
     <div className="Players">
+      <div>
+        <select name="player-type" id="player-type-dropdown" onChange={handlePlayerFilterChange}>
+          <option value={SKATERS}>Skaters</option>
+          <option value={GOALIES}>Goalies</option>
+        </select>
+      </div>
       {getPlayerTable()}
     </div>
   );

--- a/src/Components/Players/Players.js
+++ b/src/Components/Players/Players.js
@@ -18,7 +18,8 @@ const Players = () => {
     } else {
       return <div id={'PlayerStatsTable-div'}>
         <table id={'PlayerStatsTable'}>
-          <tr>
+          <tr id={'PlayerStatsTable-headers'}>
+            <th>Ranking</th>
             <th>Player Name</th>
             <th>Position</th>
             <th>Games Played</th>
@@ -39,9 +40,11 @@ const Players = () => {
             <th>PPG</th>
             <th>PPP</th>
             <th>PPTOI</th>
+            <th>GWG</th>
           </tr>
-          {allPlayers.map(player => {
+          {allPlayers.map((player, index) => {
             return <tr>
+              <td>{index + 1}</td>
               <td>{player.player.fullName}</td>
               <td>{player.position.abbreviation}</td>
               <td>{player.stats.games}</td>
@@ -62,6 +65,7 @@ const Players = () => {
               <td>{player.stats.powerPlayGoals}</td>
               <td>{player.stats.powerPlayPoints}</td>
               <td>{player.stats.powerPlayTimeOnIcePerGame}</td>
+              <td>{player.stats.gameWinningGoals}</td>
             </tr>
           })}
         </table>

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -1,21 +1,29 @@
 .Players {
   background-color: #FAF9F9;
+  display: grid;
+  grid-template-columns: 1fr 13fr 1fr;
+  grid-template-areas: '. PlayerStatsTable .';
 }
 
 #PlayerStatsTable {
   margin: 2em;
+  border-spacing: unset;
 }
 
 #PlayerStatsTable-div {
-  overflow-y: scroll;
-  //width: 90em;
-  height: 40em;
-  background-color: #FFFFFF;
+  grid-area: PlayerStatsTable;
+  overflow-y: hidden;
+  height: 48em;
+  background-color: #FAF9F9;;
+  margin-top: 1em;
   th {
     padding: 0.5em 0.5em 0.5em 0.5em;
+    background-color: #0A026E;
+    color: #FFFFFF;
+    cursor: pointer;
   }
   td {
     text-align: center;
-    padding: 0.25em 0 0.25em 0;
+    padding: 0.5em 0 0.5em 0;
   }
 }

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -25,11 +25,33 @@
 }
 
 #Players-pagination {
-  border: 0.1em solid red;
-  width: 90%;
+  padding: 0.1em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.Player-Paginator {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  p {
+    text-align: center;
+  }
+  button {
+    border: none;
+    background-color: #F0F0F0;
+    font-size: 0.9rem;
+
+    &:focus {
+      outline: None;
+    }
+  }
 }
 
 #Players-type-dropdown-div {
+}
+
+@media screen and (min-width: 1655px) {
+  #Players-pagination {
+    width: 94em;
+  }
 }

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -25,6 +25,10 @@
 }
 
 #Players-pagination {
+  border: 0.1em solid red;
+  width: 90%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
 }
 
 #Players-type-dropdown-div {

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -1,0 +1,21 @@
+.Players {
+  background-color: #FAF9F9;
+}
+
+#PlayerStatsTable {
+  margin: 2em;
+}
+
+#PlayerStatsTable-div {
+  overflow-y: scroll;
+  //width: 90em;
+  height: 40em;
+  background-color: #FFFFFF;
+  th {
+    padding: 0.5em 0.5em 0.5em 0.5em;
+  }
+  td {
+    text-align: center;
+    padding: 0.25em 0 0.25em 0;
+  }
+}

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -1,17 +1,14 @@
 .Players {
   background-color: #FAF9F9;
-  display: grid;
-  grid-template-columns: 1fr 13fr 1fr;
-  grid-template-areas: '. PlayerStatsTable .';
+  width: 80%;
+  margin: 1em auto 0 auto;
 }
 
 #PlayerStatsTable {
-  margin: 2em;
   border-spacing: unset;
 }
 
 #PlayerStatsTable-div {
-  grid-area: PlayerStatsTable;
   overflow-y: hidden;
   height: 48em;
   background-color: #FAF9F9;;
@@ -26,4 +23,10 @@
     text-align: center;
     padding: 0.5em 0 0.5em 0;
   }
+}
+
+#Players-pagination {
+}
+
+#Players-type-dropdown-div {
 }

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -50,8 +50,27 @@
 #Players-type-dropdown-div {
 }
 
+#player-type-dropdown {
+  width: 20em;
+  background-color: transparent;
+  padding: 0.5em;
+  font-size: 1rem;
+  border: none;
+  border-bottom: 0.1em solid #000000;
+
+  &:focus {
+    outline: None;
+  }
+}
+
 @media screen and (min-width: 1655px) {
   #Players-pagination {
     width: 94em;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  #player-type-dropdown {
+    width: 70%;
   }
 }

--- a/src/Components/Players/Players.scss
+++ b/src/Components/Players/Players.scss
@@ -1,6 +1,6 @@
 .Players {
   background-color: #FAF9F9;
-  width: 80%;
+  width: 90%;
   margin: 1em auto 0 auto;
 }
 
@@ -10,7 +10,6 @@
 
 #PlayerStatsTable-div {
   overflow-y: hidden;
-  height: 48em;
   background-color: #FAF9F9;;
   margin-top: 1em;
   th {

--- a/src/Extras/Constants.js
+++ b/src/Extras/Constants.js
@@ -5,3 +5,10 @@ export const BASE_LOCAL_API = 'http://localhost:5000';
 
 export const HOME = 'home';
 export const AWAY = 'away';
+
+
+export const SKATERS = 'skaters';
+export const GOALIES = 'goalies';
+
+export const GOALIE = 'g';
+

--- a/src/Extras/Constants.js
+++ b/src/Extras/Constants.js
@@ -1,6 +1,7 @@
 
 export const BASE_API = 'https://statsapi.web.nhl.com/api/v1/';
 export const BASE_LOGO_API = 'https://www-league.nhlstatic.com/images/logos/teams-current-primary-light/';
+export const BASE_LOCAL_API = 'http://localhost:5000';
 
 export const HOME = 'home';
 export const AWAY = 'away';


### PR DESCRIPTION
**Description:** Add a player stats component to the site. The component is basically a table listing all the stats of all skaters in the league. A new backend API was created in another repo, which is used to make concurrent API calls and handle some of the data processing. This new API is used to gather all of the player stats, then cache them so an API call doesn't need to be made every time the user clicks on the player stats. 

A new API was required because of how the 3rd party stats API is written. A list of players is only available through each team, so each team must be iterated through to retrieve each player id, then a separate API call must be made to gather the stats for that player. Due to the inefficiencies of this method by itself, a new API was created to handle concurrent API calls which significantly reduces the retrieval time.

**Issues:** There are still a few issues that have to be resolved, but upon further consideration, I thought it best to give them their own separate branches. 

The first issue is that the player stats don't appear in any particular order. They are most likely just being displayed as the are retrieved from the _Teams_ API call. In the future each table header should be clickable, and should sort the table based on which header was clicked.

The second issue has to do with the goalie stats. Since goalies have different stats than the players, the table must be changed in order for them to be displayed properly. This should be a separate task.

The final known issue is regarding some of the players. Some players have only a name and no data. This issue should be investigated to figure out why there is no data coming from these players, and if no data exists, these players should be excluded from the table.